### PR TITLE
Shrink Dockerfile built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM selenium/node-chrome:latest@sha256:9d24461f5ff07fda0e5b293dfd4b11a8968d2ce4
 USER root
 
 RUN apt-get update -qqy \
-  && apt-get -qqy install nodejs npm \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && rm /bin/sh && ln -s /bin/bash /bin/sh \
   && chown seluser /usr/local


### PR DESCRIPTION
Hi,

During the build phase of the current Dockerfile, it is being added a node and a npm installation to the final image, and on the next RUN command, a nvm installation is also added. I'm opening this PR to remove this extraneous node/npm installation as it is not being used to run the project. The image size of the current version is 1.1GB, and after this removal, it goes down to 901MB. This update also speeds up the image build process.

Thanks!