### PR TITLE
set comlink as a required dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     }
   ],
   "license": "Apache-2.0",
+  "dependencies": {
+    "comlinkjs": "2.3.3",
+  },
   "devDependencies": {
     "babel-minify": "0.3.0",
     "chai": "4.1.2",
-    "comlinkjs": "2.3.3",
     "eslint": "4.19.0",
     "eslint-config-google": "0.9.1",
     "karma": "2.0.0",


### PR DESCRIPTION
Why do this dependency was set on "development" since new instalations will need it in order to proper wun the library?